### PR TITLE
Add optional reporting unit investigations to EML-510

### DIFF
--- a/xsd/510-count-kiesraad-strict.xsd
+++ b/xsd/510-count-kiesraad-strict.xsd
@@ -158,6 +158,7 @@
 				<xs:element name="ReportingUnitIdentifier" type="ReportingUnitIdentifierStructureKR"/>
 				<xs:group ref="VoteGroup"/>
 			</xs:sequence>
+			<xs:attribute name="Recounted" type="xs:boolean" default="false"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:group name="VoteGroup">

--- a/xsd/510-count-kiesraad-strict.xsd
+++ b/xsd/510-count-kiesraad-strict.xsd
@@ -157,8 +157,8 @@
 			<xs:sequence>
 				<xs:element name="ReportingUnitIdentifier" type="ReportingUnitIdentifierStructureKR"/>
 				<xs:group ref="VoteGroup"/>
+				<xs:element ref="kr:ReportingUnitInvestigations" minOccurs="0" maxOccurs="1"/>
 			</xs:sequence>
-			<xs:attribute name="Recounted" type="xs:boolean" default="false"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:group name="VoteGroup">

--- a/xsd/kiesraad-eml-extensions.xsd
+++ b/xsd/kiesraad-eml-extensions.xsd
@@ -139,26 +139,32 @@
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
-	<xs:complexType name="InvestigationsDSOType">
-		<xs:sequence>
-			<xs:element name="InvestigatedUnaccountedDifference" type="xs:boolean"/>
-			<xs:element name="InvestigatedOtherError" type="xs:boolean"/>
-			<xs:element name="ResultCorrected" type="xs:boolean"/>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="InvestigationsCSOType">
-		<xs:sequence>
-			<xs:element name="AdmittedVotersRecounted" type="xs:boolean"/>
-			<xs:element name="InvestigatedOtherReason" type="xs:boolean"/>
-			<xs:element name="BallotsRecounted" type="xs:boolean"/>
-		</xs:sequence>
-	</xs:complexType>
 	<xs:element name="ReportingUnitInvestigations">
 		<xs:complexType>
-			<xs:choice>
-				<xs:element name="InvestigationsDSO" type="InvestigationsDSOType"/>
-				<xs:element name="InvestigationsCSO" type="InvestigationsCSOType"/>
-			</xs:choice>
+			<xs:sequence>
+				<xs:element name="Investigation" minOccurs="0" maxOccurs="3">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:boolean">
+								<xs:attribute name="ReasonCode" use="required">
+									<xs:simpleType>
+										<xs:restriction base="xs:token">
+											<!-- DSO -->
+											<xs:enumeration value="onderzocht vanwege onverklaard verschil"/>
+											<xs:enumeration value="onderzocht vanwege andere fout"/>
+											<xs:enumeration value="uitslag gecorrigeerd"/>
+											<!-- CSO -->
+											<xs:enumeration value="toegelaten kiezers opnieuw vastgesteld"/>
+											<xs:enumeration value="onderzocht vanwege andere reden"/>
+											<xs:enumeration value="stembiljetten deels herteld"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
 	<xs:simpleType name="PublicationLanguageType">

--- a/xsd/kiesraad-eml-extensions.xsd
+++ b/xsd/kiesraad-eml-extensions.xsd
@@ -139,6 +139,28 @@
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
+	<xs:complexType name="InvestigationsDSOType">
+		<xs:sequence>
+			<xs:element name="InvestigatedUnaccountedDifference" type="xs:boolean"/>
+			<xs:element name="InvestigatedOtherError" type="xs:boolean"/>
+			<xs:element name="ResultCorrected" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="InvestigationsCSOType">
+		<xs:sequence>
+			<xs:element name="AdmittedVotersRecounted" type="xs:boolean"/>
+			<xs:element name="InvestigatedOtherReason" type="xs:boolean"/>
+			<xs:element name="BallotsRecounted" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="ReportingUnitInvestigations">
+		<xs:complexType>
+			<xs:choice>
+				<xs:element name="InvestigationsDSO" type="InvestigationsDSOType"/>
+				<xs:element name="InvestigationsCSO" type="InvestigationsCSOType"/>
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
 	<xs:simpleType name="PublicationLanguageType">
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="nl"/>


### PR DESCRIPTION
## Changes
Adds optional reporting unit investigations to the `EML-510` files so that values from the new Na 31-1 and Na 31-2 can be registered in the EML as well as the certified election results (PVs).

See https://github.com/kiesraad/EML_NL/issues/3#issuecomment-2879858544 for more information
