### PR TITLE
Fix restrictions of `EMLstructure` and `ElectionIdentifierStructure` …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # EML_NL schema definitions
+
+> [!WARNING]  
+> The main branch of this repository might include changes which will take effect in the next version of the standard. Always check the [latest release](https://github.com/kiesraad/EML_NL/releases/latest) for the current version of the EML_NL standard!
+
 This repository contains the schema definitions for the EML_NL standard, which is a modified version of the [Election Markup Language (EML) Version 5.0](https://docs.oasis-open.org/election/eml/v5.0/EML-Schema-Descriptions-v5.0.html) by [OASIS Open](https://www.oasis-open.org/).
 
 The standard has been modified, extended and restricted to fit the Dutch electoral law.

--- a/xsd/110a-electionevent-kiesraad-strict.xsd
+++ b/xsd/110a-electionevent-kiesraad-strict.xsd
@@ -19,14 +19,12 @@
 					<xs:element ref="TransactionId"/>
 					<xs:element name="ManagingAuthority" type="ManagingAuthorityStructureKR" minOccurs="0"/>
 					<xs:element name="IssueDate" type="DateType" minOccurs="0"/>
-					<xs:choice>
+					<xs:choice minOccurs="1" maxOccurs="2">
 						<xs:annotation>
 							<xs:documentation>this choice is not logical but necessary</xs:documentation>
 						</xs:annotation>
-						<xs:sequence>
-							<xs:element ref="kr:CreationDateTime"/>
-							<xs:element ref="ds:CanonicalizationMethod" minOccurs="0"/>
-						</xs:sequence>
+						<xs:element ref="kr:CreationDateTime"/>
+						<xs:element ref="ds:CanonicalizationMethod" minOccurs="0"/>
 					</xs:choice>
 				</xs:sequence>
 				<xs:attribute name="Id" use="required" fixed="110a">
@@ -46,16 +44,14 @@
 				<xs:sequence>
 					<xs:element name="ElectionName" type="xs:token"/>
 					<xs:element name="ElectionCategory" type="kr:ElectionCategoryType"/>
-					<xs:choice>
+					<xs:choice minOccurs="3" maxOccurs="4">
 						<xs:annotation>
 							<xs:documentation>this choice is not logical but necessary</xs:documentation>
 						</xs:annotation>
-						<xs:sequence>
-							<xs:element ref="kr:ElectionSubcategory"/>
-							<xs:element ref="kr:ElectionDomain" minOccurs="0"/>
-							<xs:element ref="kr:ElectionDate"/>
-							<xs:element ref="kr:NominationDate"/>
-						</xs:sequence>
+						<xs:element ref="kr:ElectionSubcategory"/>
+						<xs:element ref="kr:ElectionDomain" minOccurs="0"/>
+						<xs:element ref="kr:ElectionDate"/>
+						<xs:element ref="kr:NominationDate"/>
 					</xs:choice>
 				</xs:sequence>
 			</xs:restriction>

--- a/xsd/110b-electionevent-kiesraad-strict.xsd
+++ b/xsd/110b-electionevent-kiesraad-strict.xsd
@@ -19,14 +19,12 @@
 					<xs:element ref="TransactionId"/>
 					<xs:element name="ManagingAuthority" type="ManagingAuthorityStructureKR"/>
 					<xs:element name="IssueDate" type="DateType" minOccurs="0"/>
-					<xs:choice>
+					<xs:choice minOccurs="1" maxOccurs="2">
 						<xs:annotation>
 							<xs:documentation>this choice is not logical but necessary</xs:documentation>
 						</xs:annotation>
-						<xs:sequence>
-							<xs:element ref="kr:CreationDateTime"/>
-							<xs:element ref="ds:CanonicalizationMethod" minOccurs="0"/>
-						</xs:sequence>
+						<xs:element ref="kr:CreationDateTime"/>
+						<xs:element ref="ds:CanonicalizationMethod" minOccurs="0"/>
 					</xs:choice>
 				</xs:sequence>
 				<xs:attribute name="Id" use="required" fixed="110b">
@@ -46,15 +44,13 @@
 				<xs:sequence>
 					<xs:element name="ElectionName" type="xs:token" minOccurs="0"/>
 					<xs:element name="ElectionCategory" type="kr:ElectionCategoryType"/>
-					<xs:choice>
+					<xs:choice minOccurs="1" maxOccurs="3">
 						<xs:annotation>
 							<xs:documentation>this choice is not logical but necessary</xs:documentation>
 						</xs:annotation>
-						<xs:sequence>
-							<xs:element ref="kr:ElectionSubcategory" minOccurs="0"/>
-							<xs:element ref="kr:ElectionDomain" minOccurs="0"/>
-							<xs:element ref="kr:ElectionDate"/>
-						</xs:sequence>
+						<xs:element ref="kr:ElectionSubcategory" minOccurs="0"/>
+						<xs:element ref="kr:ElectionDomain" minOccurs="0"/>
+						<xs:element ref="kr:ElectionDate"/>
 					</xs:choice>
 				</xs:sequence>
 			</xs:restriction>

--- a/xsd/630-optionslist-kiesraad-strict.xsd
+++ b/xsd/630-optionslist-kiesraad-strict.xsd
@@ -19,14 +19,12 @@
 					<xs:element ref="TransactionId"/>
 					<xs:element name="ManagingAuthority" type="ManagingAuthorityStructureKR" minOccurs="0"/>
 					<xs:element name="IssueDate" type="DateType" minOccurs="0"/>
-					<xs:choice>
+					<xs:choice minOccurs="1" maxOccurs="2">
 						<xs:annotation>
 							<xs:documentation>this choice is not logical but necessary</xs:documentation>
 						</xs:annotation>
-						<xs:sequence>
-							<xs:element ref="kr:CreationDateTime"/>
-							<xs:element ref="ds:CanonicalizationMethod" minOccurs="0"/>
-						</xs:sequence>
+						<xs:element ref="kr:CreationDateTime"/>
+						<xs:element ref="ds:CanonicalizationMethod" minOccurs="0"/>
 					</xs:choice>
 				</xs:sequence>
 				<xs:attribute name="Id" use="required" fixed="630">
@@ -46,15 +44,13 @@
 				<xs:sequence>
 					<xs:element name="ElectionName" type="xs:token"/>
 					<xs:element name="ElectionCategory" type="kr:ElectionCategoryType"/>
-					<xs:choice>
+					<xs:choice minOccurs="2" maxOccurs="3">
 						<xs:annotation>
 							<xs:documentation>this choice is not logical but necessary</xs:documentation>
 						</xs:annotation>
-						<xs:sequence>
-							<xs:element ref="kr:ElectionSubcategory"/>
-							<xs:element ref="kr:ElectionDomain" minOccurs="0"/>
-							<xs:element ref="kr:ElectionDate"/>
-						</xs:sequence>
+						<xs:element ref="kr:ElectionSubcategory"/>
+						<xs:element ref="kr:ElectionDomain" minOccurs="0"/>
+						<xs:element ref="kr:ElectionDate"/>
 					</xs:choice>
 				</xs:sequence>
 			</xs:restriction>


### PR DESCRIPTION
- Fixes EML-110a, EML-110b and EML-630 to valid restrictions of `EMLstructureKR` (see #13 for more details on the specifics)
- Adds a warning to the README with a link to the most recently _released_ version of the EML_NL standard to clarify that `main` can include non-released changes