### PR TITLE
Verduidelijken betekenis candidate Id in 510 and 520

### DIFF
--- a/xsd/510-count-kiesraad-strict.xsd
+++ b/xsd/510-count-kiesraad-strict.xsd
@@ -93,7 +93,7 @@
 	</xs:complexType>
 	<xs:complexType name="CandidateIdentifierStructure510">
 		<xs:annotation>
-			<xs:documentation>only CandidateName and ShortCode (Element or Attribute) allowed, Id Attribute mandatory </xs:documentation>
+			<xs:documentation>only CandidateName and ShortCode (Element or Attribute) allowed, Id Attribute mandatory when candidate number is known at this level</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:restriction base="CandidateIdentifierStructureKR">

--- a/xsd/520-result-kiesraad-strict.xsd
+++ b/xsd/520-result-kiesraad-strict.xsd
@@ -78,7 +78,7 @@
 	</xs:complexType>
 	<xs:complexType name="CandidateIdentifierStructure520">
 		<xs:annotation>
-			<xs:documentation>Id Attribute mandatory </xs:documentation>
+			<xs:documentation>Id Attribute mandatory. Does not refer to candidate number but the order in which the candidates are elected</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:restriction base="CandidateIdentifierStructureKR">


### PR DESCRIPTION
Documentatie van de `CandidateIdentifierStructure` aangepast voor de 510 en 520.

### EML 510
- Candidate id is verplicht aanwezig als deze bekend vanuit de kandidatenlijsten. Deze is dan gelijk aan het kandidaatnummer.
- Dit Id kan niet _echt_ verplicht gemaakt worden in de standaard, omdat voor verkiezingen een aggregatie plaats kan vinden naar het niveau _boven_ waar de kandidatenlijsten gedefinieerd zijn. Hier is er _geen_ uniek kandidaatnummer meer per lijst aangezien per kieskring een andere lijst ingeleverd kan worden. In die gevallen wordt de `ShortCode` gebruikt en het kandidaatnummer weggelaten.

### EML 520
- Candidate id is verplicht aanwezig, maar de betekenis is hier anders: namelijk de _volgorde waarin de kandidaten geselecteerd zijn_.
